### PR TITLE
Fixed: repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 
   "repository": {
     "type": "git",
-    "url":  "git@github.int.yammer.com:dalvarez/jscs-loader.git"
+    "url":  "https://github.com/unindented/jscs-loader"
   },
 
   "keywords": [


### PR DESCRIPTION
Because link on npmjs.org was broken.
