### PR TITLE
Fixing jscs-loader for Webpack v4+

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ var loadConfigAsync = function (callback) {
 
 var checkSource = function (source, config) {
   // Copy options to own object.
-  var options = this.options.jscs;
+  var options = this.query.jscs;
   extend(config, options);
 
   // Copy query to own object.


### PR DESCRIPTION
Fixing jscs-loader for webpack4. this.options has been deprecated for this.query https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202